### PR TITLE
chore: switch main branch to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,12 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - v*
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build-test-deploy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Please use the github issue tracker for any bugs or feature requests,
 email sent to the maintainer(s) will probably be ignored.
-If you would like to backport a feature from master to a release
+If you would like to backport a feature from main to a release
 branch, also put a ticket for enhancement.
 
 If you would like to contribute bug fixes or new components,
@@ -28,4 +28,4 @@ for you editor, or to run `yarn prettier:fix` before committing any changes.
 Automated tests are run for all pull requests with GitHub Actions, for which
 the configuration can be found in the `.github/workflows/ci.yml` file. These
 are required to pass before a PR can be merged, so please keep your PR
-up-to-date by merging the latest `master` branch.
+up-to-date by merging the latest `main` branch.


### PR DESCRIPTION
This prepares to switch the main branch from `master` to `main`. The merge request is merged to the `main` branch. After this is merged the default branch can be updated from `master` to `main` in the settings.